### PR TITLE
Update check_update_local.py

### DIFF
--- a/check_update_local.py
+++ b/check_update_local.py
@@ -3,16 +3,12 @@
 
 '''
 check_update_local.py
-
 Shows the number of (security) updates on Linux systems with yum or apt.
 Tested on Debian, Ubuntu, CentOS, Fedora (not on RHEL).
-
 On Debian-like systems, requires "update-notifier-common" package.
 On Redhat-like systems, requires "yum-plugin-security" (on Fedora11/CentOS6),
 or "yum-security" (on older Redhat).
-
 On error an unusually high positive number ([60001,60100]) will be used.
-
 Copyright: Daisuke Miyakawa (d.miyakawa (a-t) gmail d-o-t com)
 Licensed under Apache 2 License.
 '''
@@ -190,9 +186,9 @@ class RedhatTester(TesterBase):
 
     def get_update_count(self, is_security_updates=False):
         if is_security_updates:
-            cmd = 'yum --security check-update'
+            cmd = 'yum --security -q check-update'
         else:
-            cmd = 'yum check-update'
+            cmd = 'yum -q check-update'
         p = Popen(shlex.split(cmd), stderr=PIPE, stdout=PIPE)
         p.wait()
 
@@ -204,7 +200,8 @@ class RedhatTester(TesterBase):
                                .format(cmd, p.returncode,
                                        p.stderr.read().rstrip()))
         output = p.stdout.read()
-        update_lines = filter(lambda x: x.rstrip().endswith('updates'),
+        sources = ( "releases", "updates", "server-7", "ol7_UEKR4", "ol7_latest", "amzn_main" )
+        update_lines = filter(lambda x: x.rstrip().endswith(sources),
                               output.split('\n'))
         return len(update_lines)
 


### PR DESCRIPTION
I ran into some issues with check_update_local.py on Red Hat distros, so I fixed it, and thought I would share with you the fix. Please excuse my rather clumsy fix as this is maybe the fourth piece of python code I have had to hack/fix. 

The popen cmd process would hang for yum check-updates for security if the output of the cmd was too long (in my case from packages/repos being excluded). So I added a -q to both the commands, which fixes the issue. But from what I could figure out the popen should probably use the communicate() method.  

Additionally there were several updates with RHEL/CentOS/AmazonLinux sources that did not end with "updates", so I converted it to a tuple (lines 203,204) and added the unique strings that the sources I found had .

I should add that this fix does not work with Amazon Linux, nor does the original. This is because although Amazon Linux is built on RHEL, it uses /etc/os-release for version information instead of /etc/redhat-release. I am working this as well and hopefully will have an update soon